### PR TITLE
Fix `Avoid using allow_any_instance_of` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ end
 RSpec.describe Statement do
   describe '#issue' do
     let!(:client) { double('client') }
-    let!(:statement) { Statement.new }
+    let!(:statement) { Statement.new(client: client) }
 
     it 'call TwitterClient#issue' do
       expect(client).to receive(:issue).with('hello')

--- a/README_EN.md
+++ b/README_EN.md
@@ -780,7 +780,7 @@ end
 describe Statement do
   describe '#issue' do
     let!(:client) { double('client') }
-    let!(:statement) { Statement.new }
+    let!(:statement) { Statement.new(client: client) }
 
     it 'calls TwitterClient#issue' do
       expect(client).to receive(:issue).with('hello')


### PR DESCRIPTION
「allow_any_instance_ofを避ける」の例で、

<details><summary>rspecを走らせたところ、failしてしまいました。</summary>

```ruby
# a_spec.rb
class TwitterClient
  def issue(_body); end
end

class Statement
  def initialize(client: TwitterClient.new)
    @client = client
  end

  def issue(body)
    client.issue(body)
  end

  private

  def client
    @client
  end
end

RSpec.describe Statement do
  describe '#issue' do
    let!(:client) { double('client') }
    let!(:statement) { Statement.new }

    it 'call TwitterClient#issue' do
      expect(client).to receive(:issue).with('hello')
      statement.issue('hello')
    end
  end
end
```

テスト結果:

```
$ rspec a_spec.rb
F

Failures:

  1) Statement#issue call TwitterClient#issue
     Failure/Error: expect(client).to receive(:issue).with('hello')

       (Double "client").issue("hello")
           expected: 1 time with arguments: ("hello")
           received: 0 times
     # ./a_spec.rb:27:in `block (3 levels) in <top (required)>'

Finished in 0.01066 seconds (files took 0.09428 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./a_spec.rb:26 # Statement#issue call TwitterClient#issue
```

</details>

----


可能ならパスしたほうがいいと思います。

直し方は、自信ないんですが、

```diff
-    let!(:statement) { Statement.new }
+    let!(:statement) { Statement.new(client: client) }
```

でパスしました、これでどうでしょう?