### PR TITLE
Fix official rspec documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ end
 
 ## allow_any_instance_ofを避ける
 
-[公式のドキュメント](https://relishapp.com/rspec/rspec-mocks/docs/working-with-legacy-code/any-instance)にも書かれているが、`allow_any_instance_of`(`expect_any_instance_of`)が必要な時点でテスト対象の設計がおかしい可能性がある。
+[公式のドキュメント](https://rspec.info/features/3-12/rspec-mocks/working-with-legacy-code/any-instance/)にも書かれているが、`allow_any_instance_of`(`expect_any_instance_of`)が必要な時点でテスト対象の設計がおかしい可能性がある。
 
 例として、次のような`Statement#issue`のテストを書いてみる。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -730,7 +730,7 @@ When `is_expected` isn't being used, it's good forget using `subject` and just w
 
 ## Avoid using `allow_any_instance_of`
 
-It's also written in the [official documentation](https://relishapp.com/rspec/rspec-mocks/docs/working-with-legacy-code/any-instance), but there is a chance that the test's target design will bug out when using `allow_any_instance_of` (`expect_any_instance_of`).
+It's also written in the [official documentation](https://rspec.info/features/3-12/rspec-mocks/working-with-legacy-code/any-instance/), but there is a chance that the test's target design will bug out when using `allow_any_instance_of` (`expect_any_instance_of`).
 
 As an example, Let's write a test for `Statement#issue`
 


### PR DESCRIPTION
RSpecの公式ドキュメントが https://rspec.info でホストされるようになったため、リンクを修正しました。